### PR TITLE
Transform empty-string argument

### DIFF
--- a/src/rsql.js
+++ b/src/rsql.js
@@ -24,6 +24,9 @@ export function toRsqlValue (value) {
   if (Array.isArray(value)) {
     return `(${value.map(toRsqlValue).join()})`
   }
+  if (value.length === 0) {
+    return "''"
+  }
   return containsRsqlReservedCharacter(value) ? rsqlEscape(value) : value
 }
 

--- a/test/unit/specs/rsql.spec.js
+++ b/test/unit/specs/rsql.spec.js
@@ -29,6 +29,14 @@ describe('rsql', () => {
       })).to.equal('x==5;y==3')
     })
 
+    it('should transform empty-string argument: x==\'\'', () => {
+      expect(transformToRSQL({
+        selector: 'x',
+        comparison: '==',
+        arguments: ''
+      })).to.equal("x==''")
+    })
+
     describe('should add brackets around OR expressions with AND parent', () => {
       it('should not wrap OR with single operand: z==3;w==3', () => {
         expect(transformToRSQL({


### PR DESCRIPTION
Added extra case to convert an empty-string argument to valid RSQL
empty string.

Fixes #10

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- N/A User documentation updated
- [x] Clean commits
- [x] No warnings during install
- N/A Updated flow typing
- [x] Added Feature/Fix to release notes
