### PR TITLE
fix: ci build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,7 @@ pipeline {
             steps {
                 milestone 2
                 container('node') {
+                    sh "npm config set unsafe-perm true"
                     sh "npx semantic-release"
                 }
             }


### PR DESCRIPTION
Set npm unsafe-perm to true to allow CI root user to buld/release

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
- [ ] Added Feature/Fix to release notes
